### PR TITLE
use get variable url for whitelist domains, fix service_url test

### DIFF
--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -13,7 +13,7 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
-if (is_executable($this->config['htmltopdf_path'])) {
+if (is_executable($this->config['htmltopdf_path']) || !empty($this->config['htmltopdf_service_url'])) {
     $dir = getcwd();
     $url = str_replace(array('/wakka.php?wiki=', '/?'), '', $this->config['base_url']);
     $dlFilename = str_replace(
@@ -23,7 +23,7 @@ if (is_executable($this->config['htmltopdf_path'])) {
     ).'-'.$this->GetPageTag().".pdf";
     $fullFilename = $dir."/cache/".$dlFilename;
     if (!empty($_GET['url'])) {
-        $domain = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST);
+        $domain = parse_url($_GET['url'], PHP_URL_HOST);
         if (in_array($domain, $this->config['htmltopdf_service_authorized_domains'])) {
             $sourceUrl = $_GET['url'];
             $_GET['refresh']=1; //for external pdfs, no cache
@@ -111,4 +111,3 @@ if (is_executable($this->config['htmltopdf_path'])) {
       .'.</div>'."\n";
     echo $this->Footer()."\n";
 }
-


### PR DESCRIPTION
hi @oncletom !
Avec @hadide , on a testé l'utilisation d'une instance externe pour générer le pdf (use case : si l'hébergement du wiki ne permet pas d'ajouter d'ajouter chromium, on utilise une url d'instance de yeswiki le permettant, et sur laquelle l'url du premier wiki est autorisée).  

Ci joint une PR qui permet de faire marcher cette feature.

Nous avons testé sur https://wiki.hinaura.fr/?EbookAnnuaireMednum et il semblerait qu'il y ai des soucis de style, pourrais tu voir si c'est normal avec Adrien ? 

Merci et bonne journée!