### PR TITLE
Improve refresh

### DIFF
--- a/actions/bazar2publication.php
+++ b/actions/bazar2publication.php
@@ -22,9 +22,15 @@ $publicationTemplate = $wiki->getParameter('templatepage') ? $wiki->loadPage($wi
 
 $template = new SquelettePhp('bazar2publication.tpl.html', 'publication');
 
-$href = $wiki->Href('pdf', null, array(
-  'via' => 'bazarliste',
-  'template-page' => $wiki->getParameter('templatepage'),
+$queries = $_GET;
+//remove wiki
+if (array_key_exists('wiki', $queries)) {
+    unset($queries['wiki']);
+}
+$href = $wiki->Href('pdf', null, $queries// merge GET with wiki and following params
+  +array(
+    'via' => 'bazarliste',
+    'template-page' => $wiki->getParameter('templatepage'),
 ));
 
 echo $template->render(array(

--- a/config.yaml
+++ b/config.yaml
@@ -38,3 +38,15 @@ parameters:
   # Use cases: reverse-proxy, within a YesWiki Docker container.
   htmltopdf_base_url: ~
   #htmltopdf_base_url: http://localhost:8000/?
+  #
+  # for edit config action
+  publication_editable_config_params:
+    - 'htmltopdf_service_url'
+
+services:
+  _defaults:
+    autowire: true
+    public: true
+
+  YesWiki\Publication\Service\:
+    resource: 'services/*'

--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -53,7 +53,7 @@ if (!empty($_GET['url'])) {
     $hash = substr(sha1($pagedjs_hash . json_encode(array_merge(
         $this->page,
         ['query_string' => strtolower($_SERVER['QUERY_STRING']),
-        $pdfHelper->getDataToCheck(
+        $pdfHelper->getPageEntriesContent(
             $pageTag,
             $_GET['via'] ?? null
         ) ?? []]

--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -63,6 +63,10 @@ $dlFilename = sprintf(
     $hash
 );
 
+$dirname = sys_get_temp_dir()."/yeswiki/";
+if (!file_exists($dirname)) {
+    mkdir($dirname);
+}
 $fullFilename = sprintf(
     '%s/yeswiki/%s-%s-%s.pdf',
     sys_get_temp_dir(),

--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -8,6 +8,8 @@ Copyright 2014 Outils-Réseaux
 
 */
 
+use YesWiki\Publication\Service\PdfHelper;
+
 // Verification de securite
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
@@ -45,9 +47,16 @@ if (!empty($_GET['url'])) {
     $pageTag = $this->GetPageTag();
     $pdfTag = $this->MiniHref('pdf', $pageTag);
     $sourceUrl = $this->href('preview', $pageTag, preg_replace('#^'. $pdfTag .'&?#', '', $_SERVER['QUERY_STRING']), false);
+    
+    $pdfHelper = $this->services->get(PdfHelper::class);
+
     $hash = substr(sha1($pagedjs_hash . json_encode(array_merge(
         $this->page,
-        ['query_string' => strtolower($_SERVER['QUERY_STRING'])]
+        ['query_string' => strtolower($_SERVER['QUERY_STRING']),
+        $pdfHelper->getDataToCheck(
+            $pageTag,
+            $_GET['via'] ?? null
+        ) ?? []]
     ))), 0, 10);
 
     // In case we are behind a proxy (like a Docker container)

--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -83,7 +83,7 @@ if (($this->UserIsAdmin() && isset($_GET['print-debug']))
 || !$file_exists
 || ($file_exists && isset($_GET['refresh']) && $_GET['refresh']==1)) {
     if (!empty($this->config['htmltopdf_service_url'])) {
-        $url = $this->config['htmltopdf_service_url'].'&urlPageTag='.$this->GetPageTag().'&url='.urlencode($sourceUrl);
+        $url = $this->config['htmltopdf_service_url'].'&urlPageTag='.$this->GetPageTag().'&url='.urlencode($sourceUrl).'&hash='.$hash;
         header('Location: '.$url);
         exit;
     } else {

--- a/handlers/page/pdf.php
+++ b/handlers/page/pdf.php
@@ -38,7 +38,6 @@ $pagedjs_hash = sha1(json_encode(array_merge([
 ])));
 
 if (!empty($_GET['url'])) {
-    $fullFilename = '/tmp/page.pdf';
     $pageTag = isset($_GET['urlPageTag']) ? $_GET['urlPageTag'] : 'publication';
     $sourceUrl = $_GET['url'];
     $hash = substr(sha1($pagedjs_hash . strtolower($_SERVER['QUERY_STRING'])), 0, 10);
@@ -74,9 +73,7 @@ $fullFilename = sprintf(
 
 
 $file_exists = file_exists($fullFilename);
-$fileLastModifiedTime = $file_exists ? @filemtime($fullFilename) : 0;  // returns FALSE if file does not exist
 $output = array();
-$DEBUG = $this->GetConfigValue('debug')==='yes';
 
 if (($this->UserIsAdmin() && isset($_GET['print-debug']))
 || !$file_exists

--- a/handlers/page/preview.php
+++ b/handlers/page/preview.php
@@ -19,7 +19,7 @@ $templateEngine = $wiki->services->get(TemplateEngine::class);
 if ($wiki->HasAccess('read') && isset($_GET['via']) && $_GET['via'] === 'bazarliste') {
     // we assemble bazar pages
     $content = '';
-    $templateName = 'merged-entries.tpl.html';
+    $templateName = 'rendered-entries.tpl.html';
     if (!$templateEngine->hasTemplate('@bazar/'.$templateName)) {
         // backward compatibilty
         preg_match('#{{\s*bazar.+id="(.+)".+}}#siU', $wiki->page['body'], $matches);

--- a/services/PdfHelper.php
+++ b/services/PdfHelper.php
@@ -36,7 +36,19 @@ class PdfHelper
     }
 
     /**
-     * return content to add to sha1 formatted as array
+     * Check if the current page to export to pdf is :
+     *  - an entry
+     *  - a page called with $_GET['bazarliste']
+     *
+     * If an entry, get content from eventually associated template fiche-x.tpl.html
+     * If called by 'bazarliste', get content from eventually associated templates fiche-x.tpl.html
+     *  and date of the last modified entry.
+     *
+     * Return an array containing these data to gives that to sha1 function to obtain an hash depnding
+     * of templates content or date of latest entry.
+     *
+     * Aim : force generation of a new pdf file if the associated entry template or an entry of the forms were modified.
+     *
      * @param string $pageTag
      * @param null|string $get
      * @return array
@@ -87,6 +99,7 @@ class PdfHelper
 
     /**
      * rerieve fiche-X.tpl.html path and filename form formId
+     * TODO : update TemplateEngine with a new function that allow to extract that instead of the current function
      * @param string $formId
      * @return string|null $path
      */

--- a/services/PdfHelper.php
+++ b/services/PdfHelper.php
@@ -50,7 +50,6 @@ class PdfHelper
             $templatePath = $this->getTemplatePathFormFormId($formId);
             if (!empty($templatePath)) {
                 $return['template content'] = file_get_contents($templatePath);
-                echo 'pageTag : '.$pageTag.';template : '.$templatePath."\n";
             }
         } elseif ($via === 'bazarliste') {
             $page = $this->pageManager->getOne($pageTag);

--- a/services/PdfHelper.php
+++ b/services/PdfHelper.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace YesWiki\Publication\Service;
+
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\YesWikiController;
+use YesWiki\Core\Service\DbService;
+use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\Service\TemplateEngine;
+
+class PdfHelper
+{
+    private const PATH_LIST = [
+        'custom/templates/bazar/',
+        'custom/templates/bazar/templates/',
+        'themes/tools/bazar/presentation/templates/',
+        'themes/tools/bazar/templates/',
+        'tools/bazar/presentation/templates/',
+    ];
+
+    protected $dbService;
+    protected $entryManager;
+    protected $templateEngine;
+    protected $pageManager;
+
+    public function __construct(
+        DbService $dbService,
+        EntryManager $entryManager,
+        TemplateEngine $templateEngine,
+        PageManager $pageManager
+    ) {
+        $this->dbService = $dbService;
+        $this->entryManager = $entryManager;
+        $this->templateEngine = $templateEngine;
+        $this->pageManager = $pageManager;
+    }
+
+    /**
+     * return content to add to sha1 formatted as array
+     * @param string $pageTag
+     * @param null|string $get
+     * @return array
+     */
+    public function getDataToCheck(string $pageTag, ?string $via = null): array
+    {
+        $return = [];
+        if ($this->entryManager->isEntry($pageTag)) {
+            $entry = $this->entryManager->getOne($pageTag);
+            $formId = $entry['id_typeannonce'];
+            $templatePath = $this->getTemplatePathFormFormId($formId);
+            if (!empty($templatePath)) {
+                $return['template content'] = file_get_contents($templatePath);
+                echo 'pageTag : '.$pageTag.';template : '.$templatePath."\n";
+            }
+        } elseif ($via === 'bazarliste') {
+            $page = $this->pageManager->getOne($pageTag);
+            if ($page && preg_match('/({{(bazarliste|bazarcarto|calendrier|map|gogomap)\s[^}]*}})/i', $page['body'], $matches)) {
+                if (preg_match_all('/([a-zA-Z0-9_]*)=\"(.*)\"/U', $matches[1], $matchesLevel2)) {
+                    $params = [];
+                    $matches = [];
+                    foreach ($matchesLevel2[0] as $id => $match) {
+                        $params[$matchesLevel2[1][$id]] = $matchesLevel2[2][$id];
+                    }
+                    $ids = explode(',', $params['id'] ?? null);
+                    if (!empty($ids)) {
+                        $ids = array_map(function ($id) {
+                            return trim($id);
+                        }, $ids);
+                        $ids = array_filter($ids, function ($id) {
+                            return ((substr($id, 0, 4) != 'http') && (strval(intval($id)) == strval($id)));
+                        });
+                    }
+                    if (!empty($ids)) {
+                        $return['entries last-date'] = $this->getLastDateOfEntries($ids);
+                        foreach ($ids as $id) {
+                            $templatePath = $this->getTemplatePathFormFormId($id);
+                            if (!empty($templatePath)) {
+                                $return['template fiche-'.$id] = file_get_contents($templatePath);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return $return;
+    }
+
+    /**
+     * rerieve fiche-X.tpl.html path and filename form formId
+     * @param string $formId
+     * @return string|null $path
+     */
+    private function getTemplatePathFormFormId(string $formId): ?string
+    {
+        $templateFileName = 'fiche-'.trim($formId);
+        if ($this->templateEngine->hasTemplate('@bazar/'.$templateFileName.'.tpl.html')) {
+            $templateFileName .= '.tpl.html';
+        } elseif ($this->templateEngine->hasTemplate('@bazar/'.$templateFileName.'.twig')) {
+            $templateFileName .= '.twig';
+        } else {
+            $templateFileName = '';
+        }
+        
+        if (!empty($templateFileName)) {
+            foreach (self::PATH_LIST as $path) {
+                if (file_exists($path.$templateFileName)) {
+                    return $path.$templateFileName;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * find date of last entry of the forms
+     * @param array $formsIds
+     * @return string $date
+     */
+    private function getLastDateOfEntries(array $formsIds): string
+    {
+        $EntriesRequest =
+            'SELECT DISTINCT resource FROM ' . $this->dbService->prefixTable('triples') .
+            'WHERE value = "fiche_bazar" AND property = "http://outils-reseaux.org/_vocabulary/type" ' .
+            'ORDER BY resource ASC';
+        $FormIdRequest = join(
+            ' OR ',
+            array_map(function ($id) {
+                return 'body LIKE \'%"id_typeannonce":"'.trim($id).'"%\'';
+            }, $formsIds)
+        );
+
+        if (empty($FormIdRequest)) {
+            throw new \Exception("No form id request ! \$formsIds = ".json_encode($formsIds));
+        }
+
+        $SQLRequest =
+        'SELECT DISTINCT time FROM ' . $this->dbService->prefixTable('pages') . ' '.
+        'WHERE latest="Y" AND comment_on = \'\' ' .
+        'AND ('.$FormIdRequest.') ' .
+        'AND tag IN (' . $EntriesRequest . ') '.
+        'ORDER BY time DESC '.
+        'LIMIT 1';
+
+        $results = $this->dbService->loadAll($SQLRequest);
+
+        return !empty($results) ? $results[array_key_first($results)]['time'] : '';
+    }
+}

--- a/services/PdfHelper.php
+++ b/services/PdfHelper.php
@@ -53,7 +53,7 @@ class PdfHelper
      * @param null|string $get
      * @return array
      */
-    public function getDataToCheck(string $pageTag, ?string $via = null): array
+    public function getPageEntriesContent(string $pageTag, ?string $via = null): array
     {
         $return = [];
         if ($this->entryManager->isEntry($pageTag)) {


### PR DESCRIPTION
Je fais une proposition pour améliorer la gestion des mises à jour des pages.

**Ce que ça fait**:
 - ajouter la date de la dernière modification de la page dans l'url `&pageTime=`
 - comparer la date de la page courante avec celle du fichier pour s'assurer qu'il ne faut pas mettre à jour.
**Objectif**:
 - permettre une mise à jour du fichier pdf quand la page d'origine a été mise à jour

**Je la mets en relecture jusqu'à lundi**, après je pense la déployer pour permettre des tests par les utilisateurs (mais j'assurerai le suivi des modifications si ça ne va pas).