### PR TITLE
fix(bazar/entries/view): add export button for entries

### DIFF
--- a/templates/bazar/entries/_publication_button.twig
+++ b/templates/bazar/entries/_publication_button.twig
@@ -1,0 +1,6 @@
+<a class="btn btn-entry-action btn-sm btn-default"
+    href="{{ entry['external-data'] ? entry.url ~ '/pdf' : url({ tag: entryId, handler: 'pdf' }) }}"
+    title="{{ _t('PUBLICATION_EXPORT_PAGE_TO_PDF') }}">
+    <i class="fas fa-book"></i>
+    {{~ _t('PUBLICATION_EXPORT_PAGE_TO_PDF') ~}}
+</a>

--- a/templates/bazar/entries/view.twig
+++ b/templates/bazar/entries/view.twig
@@ -1,0 +1,4 @@
+{# prepend publication button at the top of BAZ_actions_fiche part #}
+{{ include('tools/bazar/templates/entries/view.twig')
+    |replace({'<div class="BAZ_actions_fiche">':
+    '<div class="BAZ_actions_fiche">'~include('@bazar/entries/_publication_button.twig')})|raw }}


### PR DESCRIPTION
Je propose d'ajouter quelques templates pour personnaliser la barre d'action des fiches bazar et ajouter un bouton "Exporter au format pdf" dans cette barre d'action et avant les boutons "Voir la fiche" "modifier".
_En effet, avec les dernières versions de YesWiki, l'action `{{barredaction}}` n'est pas affichée pour les fiches et nous n'avons donc pas le lien d'impression (alors qu'il est bien visible pour les pages).
![image](https://user-images.githubusercontent.com/67152407/137503310-b6c8a190-a338-459d-81a3-9c2f94d451d4.png)
