### PR TITLE
fix(PdfHelper): create a directory at root of tmp folder

### DIFF
--- a/services/PdfHelper.php
+++ b/services/PdfHelper.php
@@ -213,11 +213,7 @@ class PdfHelper
                 )
             )
         );
-        $dirname = sys_get_temp_dir()."/yeswiki/";
-        if (!file_exists($dirname)) {
-            mkdir($dirname);
-        }
-        $dirname = "$dirname$sanitizeWebsiteName/";
+        $dirname = sys_get_temp_dir()."/yeswiki-$sanitizeWebsiteName/";
         if (!file_exists($dirname)) {
             mkdir($dirname);
         }

--- a/tests/services/PdfHelperTest.php
+++ b/tests/services/PdfHelperTest.php
@@ -413,7 +413,7 @@ class PdfHelperTest extends YesWikiTestCase
                 'expected' => [
                     'pageTag' => '{{rootPageTag}}',
                     'dlFilename' => 'regexp:/^{{rootPageTag}}-{{hash}}\.pdf$/',
-                    'fullFilename' => 'regexp:/.+\/yeswiki\/[A-Za-z0-9\-]+\/{{rootPageTag}}-publication-{{hash}}\.pdf$/',
+                    'fullFilename' => 'regexp:/.+\/yeswiki-[A-Za-z0-9\-]+\/{{rootPageTag}}-publication-{{hash}}\.pdf$/',
                     'hash' => 'regexp:/^[A-Fa-f0-9]{10,}$/',
                     'sourceUrl' => 'regexp:/^https?:\/\/.+\/\??{{rootPageTag}}\/preview.*$/'
                 ],
@@ -428,7 +428,7 @@ class PdfHelperTest extends YesWikiTestCase
                 'expected' => [
                     'pageTag' => 'publication',
                     'dlFilename' => 'regexp:/^publication-{{hash}}\.pdf$/',
-                    'fullFilename' => 'regexp:/.+\/yeswiki\/[A-Za-z0-9\-]+\/publication-publication-{{hash}}\.pdf$/',
+                    'fullFilename' => 'regexp:/.+\/yeswiki-[A-Za-z0-9\-]+\/publication-publication-{{hash}}\.pdf$/',
                     'hash' => 'regexp:/^[A-Fa-f0-9]{10,}$/',
                     'sourceUrl' => 'regexp:/^http:\/\/localhost\/\?TesT\/preview$/'
                 ],
@@ -444,7 +444,7 @@ class PdfHelperTest extends YesWikiTestCase
                 'expected' => [
                     'pageTag' => 'TesT',
                     'dlFilename' => 'regexp:/^TesT-{{hash}}\.pdf$/',
-                    'fullFilename' => 'regexp:/.+\/yeswiki\/[A-Za-z0-9\-]+\/TesT-publication-{{hash}}\.pdf$/',
+                    'fullFilename' => 'regexp:/.+\/yeswiki-[A-Za-z0-9\-]+\/TesT-publication-{{hash}}\.pdf$/',
                     'hash' => 'regexp:/^[A-Fa-f0-9]{10,}$/',
                     'sourceUrl' => 'regexp:/^http:\/\/localhost\/\?TesT\/preview$/'
                 ],


### PR DESCRIPTION
**Objective**
Resolve #62

**Context**
In multi-site environnement, the first website creating a folder in tmp folder has rights on the created folder but not the other users.

**What the new commits do**
use `tmp/yeswiki-example-com-wiki/` folder

@mrflos merci pour ta vigilance, je n'avais pas fait attention à la précision.
Je te propose cette PR. Je te laisse la valider si ça correspond.
Je ferai la fusion après validation.